### PR TITLE
Fix hacky superclassing and downgrade an error into a warning

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -1403,7 +1403,8 @@ begin_block	: '{' top_compstmt '}'
 
 bodystmt	: compstmt
 		  opt_rescue
-		  k_else {if (!$2) {yyerror1(&@3, "else without rescue is useless");}}
+		//  k_else {if (!$2) {yyerror1(&@3, "else without rescue is useless");}}
+		  k_else {if (!$2) {rb_warn0("else without rescue is useless");}}
 		  compstmt
 		  opt_ensure
 		    {

--- a/spec/ruby/language/rescue_spec.rb
+++ b/spec/ruby/language/rescue_spec.rb
@@ -238,6 +238,7 @@ describe "The rescue keyword" do
     ScratchPad.recorded.should == [:one, :else_ran, :ensure_ran, :outside_begin]
   end
 
+if false
   it "raises SyntaxError when else is used without rescue and ensure" do
     -> {
       eval <<-ruby
@@ -249,6 +250,7 @@ describe "The rescue keyword" do
       ruby
     }.should raise_error(SyntaxError, /else without rescue is useless/)
   end
+end
 
   it "will not execute an else block if an exception was raised" do
     result = begin

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -16,6 +16,7 @@ class TestParse < Test::Unit::TestCase
     assert_syntax_error('------,,', /\n\z/, 'Message to pipe should end with a newline')
   end
 
+if false
   def test_else_without_rescue
     assert_syntax_error(<<-END, %r":#{__LINE__+2}: else without rescue"o, [__FILE__, __LINE__+1])
       begin
@@ -24,6 +25,7 @@ class TestParse < Test::Unit::TestCase
       end
     END
   end
+end
 
   def test_alias_backref
     assert_syntax_error("#{<<~"begin;"}\n#{<<~'end;'}", /can't make alias/) do

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4483,10 +4483,11 @@ vm_check_if_class(ID id, rb_num_t flags, VALUE super, VALUE klass)
 
     // edited for mkxp-z
     // makes some hackier forms of subclassing possible again
-	if (0) { //tmp != super) {
-	    rb_raise(rb_eTypeError,
-		     "superclass mismatch for class %"PRIsVALUE"",
-		     rb_id2str(id));
+	if (tmp != super) {
+	    return klass == 1 ? -1 : 1;
+	    //rb_raise(rb_eTypeError,
+		//     "superclass mismatch for class %"PRIsVALUE"",
+		//     rb_id2str(id));
 	}
 	else {
 	    return klass;
@@ -4566,11 +4567,18 @@ vm_define_class(ID id, rb_num_t flags, VALUE cbase, VALUE super)
     /* find klass */
     rb_autoload_load(cbase, id);
     if ((klass = vm_const_get_under(id, flags, cbase)) != 0) {
-        if (!vm_check_if_class(id, flags, super, klass))
+        // edited for mkxp-z
+        // makes some hackier forms of subclassing possible again
+        VALUE ret = vm_check_if_class(id, flags, super, klass);
+        if (!ret) {
             unmatched_redefinition("class", cbase, id, klass);
+        } else if (ret != klass) {
+            goto override_class;
+        }
         return klass;
     }
     else {
+override_class:
 	return vm_declare_class(id, flags, cbase, super);
     }
 }


### PR DESCRIPTION
Fixes hacky superclassing, as discussed in mkxp-z/mkxp-z#179.

Also downgrades the "else without rescue is useless" error back into a warning, as it was before ruby 2.6.